### PR TITLE
Add agreements to twfy-votes

### DIFF
--- a/data/policies/1030.yml
+++ b/data/policies/1030.yml
@@ -454,4 +454,13 @@ division_links:
   status: active
   notes: ''
   decision_type: division
-agreement_links: []
+agreement_links:
+  - decision:
+      chamber_slug: commons
+      date: 2019-06-24
+      decision_ref: b.530.1
+    alignment: agree
+    strength: weak
+    status: active
+    notes: ''
+    decision_type: agreement

--- a/data/raw/agreements.yaml
+++ b/data/raw/agreements.yaml
@@ -1,0 +1,12 @@
+- chamber_slug: commons
+  date: 2023-10-25
+  decision_ref: c.936.7
+  division_name: Approval of Committee on Standards report suspending Peter Bone
+- chamber_slug: commons
+  date: 2021-11-16
+  decision_ref: d.489.1
+  division_name: Approval of Committee on Standards report on Owen Patterson (after resignation)
+- chamber_slug: commons
+  date: 2019-06-24
+  decision_ref: b.530.1
+  division_name: Approval of SI setting 2050 Net Zero target date

--- a/databases/schema.yaml
+++ b/databases/schema.yaml
@@ -171,6 +171,13 @@ policies:
     date DATE, decision_ref VARCHAR, division_name VARCHAR, "key" VARCHAR, source_gid
     VARCHAR), decision_key VARCHAR, decision_type VARCHAR, notes VARCHAR, status VARCHAR,
     strength VARCHAR)[]
+policy_agreement_count:
+  person_id: BIGINT
+  policy_id: BIGINT
+  num_strong_agreements_same: HUGEINT
+  num_strong_agreements_different: HUGEINT
+  num_weak_agreements_same: HUGEINT
+  num_weak_agreements_different: HUGEINT
 policy_agreements:
   policy_id: BIGINT
   division_date: DATE

--- a/databases/schema.yaml
+++ b/databases/schema.yaml
@@ -1,4 +1,15 @@
 # This is an automatically generated file on database load to reflect changes in tables
+cm_agreement_present:
+  key: VARCHAR
+  mp_id: BIGINT
+  chamber_slug: VARCHAR
+  vote: VARCHAR
+  person__first_name: VARCHAR
+  person__last_name: VARCHAR
+  person__nice_name: VARCHAR
+  person__party: VARCHAR
+  membership_id: BIGINT
+  person__person_id: BIGINT
 cm_votes_with_people:
   division_id: BIGINT
   mp_id: BIGINT
@@ -156,7 +167,10 @@ policies:
   division_links: STRUCT(alignment VARCHAR, decision STRUCT(chamber_slug VARCHAR,
     date DATE, division_number BIGINT, "key" VARCHAR), decision_key VARCHAR, decision_type
     VARCHAR, notes VARCHAR, status VARCHAR, strength VARCHAR)[]
-  agreement_links: INTEGER[]
+  agreement_links: STRUCT(alignment VARCHAR, decision STRUCT(chamber_slug VARCHAR,
+    date DATE, decision_ref VARCHAR, division_name VARCHAR, "key" VARCHAR, source_gid
+    VARCHAR), decision_key VARCHAR, decision_type VARCHAR, notes VARCHAR, status VARCHAR,
+    strength VARCHAR)[]
 policy_distributions:
   is_target: INTEGER
   policy_id: BIGINT
@@ -192,6 +206,13 @@ policy_votes_with_id:
   alignment: VARCHAR
   notes: VARCHAR
   division_id: BIGINT
+pw_agreements:
+  chamber_slug: VARCHAR
+  date: DATE
+  decision_ref: VARCHAR
+  division_name: VARCHAR
+  key: VARCHAR
+  source_gid: VARCHAR
 pw_chamber_division_span:
   chamber_slug: VARCHAR
   latest_year: VARCHAR

--- a/databases/schema.yaml
+++ b/databases/schema.yaml
@@ -171,6 +171,16 @@ policies:
     date DATE, decision_ref VARCHAR, division_name VARCHAR, "key" VARCHAR, source_gid
     VARCHAR), decision_key VARCHAR, decision_type VARCHAR, notes VARCHAR, status VARCHAR,
     strength VARCHAR)[]
+policy_agreements:
+  policy_id: BIGINT
+  division_date: DATE
+  chamber: VARCHAR
+  decision_ref: VARCHAR
+  key: VARCHAR
+  strength: VARCHAR
+  strong_int: BIGINT
+  alignment: VARCHAR
+  notes: VARCHAR
 policy_distributions:
   is_target: INTEGER
   policy_id: BIGINT

--- a/src/twfy_votes/__main__.py
+++ b/src/twfy_votes/__main__.py
@@ -141,13 +141,15 @@ async def create_voting_records(
 @app.command()
 @coroutine
 @load_db
-async def validate_voting_records(sample_size: int = 10):
+async def validate_voting_records(
+    sample_size: int = 10, policy_id: Optional[int] = None
+):
     """
     Run a validation on a random sample of voting records.
     """
     from .apps.policies.vr_validator import test_policy_sample
 
-    await test_policy_sample(sample_size)
+    await test_policy_sample(sample_size, policy_id)
 
 
 @app.command()

--- a/src/twfy_votes/apps/decisions/dependencies.py
+++ b/src/twfy_votes/apps/decisions/dependencies.py
@@ -17,9 +17,9 @@ from .models import (
     AllowedChambers,
     Chamber,
     ChamberWithYearRange,
+    DecisionListing,
     DivisionAndVotes,
     DivisionInfo,
-    DivisionListing,
     PartialAgreement,
     PartialDivision,
     Person,
@@ -85,17 +85,17 @@ async def GetAgreementAndVotes(agreement: GetAgreement) -> AgreementAndVotes:
     return await AgreementAndVotes.from_agreement(agreement)
 
 
-@dependency_alias_for(DivisionListing)
-async def GetDivisionListing(
+@dependency_alias_for(DecisionListing)
+async def GetDecisionListing(
     chamber: GetChamber, year: int, month: int | None = None
-) -> DivisionListing:
+) -> DecisionListing:
     """
     Get a list of divisions for a chamber and year
     """
     if month:
-        return await DivisionListing.from_chamber_year_month(chamber, year, month)
+        return await DecisionListing.from_chamber_year_month(chamber, year, month)
     else:
-        return await DivisionListing.from_chamber_year(chamber, year)
+        return await DecisionListing.from_chamber_year(chamber, year)
 
 
 @dependency_alias_for(list[ChamberWithYearRange])

--- a/src/twfy_votes/apps/decisions/dependencies.py
+++ b/src/twfy_votes/apps/decisions/dependencies.py
@@ -9,18 +9,22 @@ from __future__ import annotations
 
 import datetime
 from typing import Literal
+
 from ...helpers.static_fastapi.dependencies import dependency_alias_for
 from .models import (
+    AgreementAndVotes,
+    AgreementInfo,
     AllowedChambers,
     Chamber,
     ChamberWithYearRange,
     DivisionAndVotes,
     DivisionInfo,
     DivisionListing,
+    PartialAgreement,
     PartialDivision,
     Person,
-    PersonAndVotes,
     PersonAndRecords,
+    PersonAndVotes,
 )
 
 
@@ -58,6 +62,27 @@ async def GetDivisionAndVotes(division: GetDivision) -> DivisionAndVotes:
     Fetch the full votes from a division object
     """
     return await DivisionAndVotes.from_division(division)
+
+
+@dependency_alias_for(AgreementInfo)
+async def GetAgreement(
+    chamber_slug: AllowedChambers, date: datetime.date, decision_ref: str
+) -> AgreementInfo:
+    """
+    Get a partial agreement and elevate it to a full agreement
+    """
+    partial = PartialAgreement(
+        chamber_slug=chamber_slug, date=date, decision_ref=decision_ref
+    )
+    return await AgreementInfo.from_partial(partial)
+
+
+@dependency_alias_for(AgreementAndVotes)
+async def GetAgreementAndVotes(agreement: GetAgreement) -> AgreementAndVotes:
+    """
+    Fetch the full votes from a division object
+    """
+    return await AgreementAndVotes.from_agreement(agreement)
 
 
 @dependency_alias_for(DivisionListing)

--- a/src/twfy_votes/apps/decisions/models.py
+++ b/src/twfy_votes/apps/decisions/models.py
@@ -19,6 +19,8 @@ from ...internal.db import duck_core
 from ..policies.queries import GetPersonParties
 from .analysis import is_nonaction_vote
 from .queries import (
+    AgreementKeyVotesQuery,
+    AgreementQueryKeys,
     ChamberDivisionsQuery,
     DivisionBreakDownQuery,
     DivisionIdsVotesQuery,
@@ -53,6 +55,7 @@ class VotePosition(StrEnum):
     ABSENT = "absent"
     TELLNO = "tellno"
     TELLAYE = "tellaye"
+    COLLECTIVE = "collective"  # used for votes where the whole chamber votes as one
 
 
 class VoteType(StrEnum):
@@ -175,21 +178,32 @@ class Chamber(BaseModel):
             case _:
                 raise ValueError(f"Invalid house slug {self.slug}")
 
-    def twfy_debate_link(self, gid: str) -> str:
-        link_format = "https://www.theyworkforyou.com/{debate_slug}/?id={gid}"
+    def pw_alias(self):
+        # Alias for internal debate storage
         match self.slug:
             case "commons":
-                return link_format.format(debate_slug="debates", gid=gid)
+                return "debate"
+            case _:
+                return self.twfy_alias()
+
+    def twfy_alias(self):
+        # Alias for internal debate storage
+        match self.slug:
+            case "commons":
+                return "debates"
             case "lords":
-                return link_format.format(debate_slug="lords", gid=gid)
+                return "lords"
             case "scotland":
-                return link_format.format(debate_slug="sp", gid=gid)
+                return "sp"
             case "wales":
-                return link_format.format(debate_slug="senedd", gid=gid)
+                return "senedd"
             case "ni":
-                return link_format.format(debate_slug="ni", gid=gid)
+                return "ni"
             case _:
                 raise ValueError(f"Invalid house slug {self.slug}")
+
+    def twfy_debate_link(self, gid: str) -> str:
+        return f"https://www.theyworkforyou.com/{self.twfy_alias()}/?id={gid}"
 
 
 class ChamberWithYearRange(BaseModel):
@@ -274,7 +288,7 @@ class Vote(BaseModel):
     membership_id: int
     division: DivisionInfo | None = None
     vote: VotePosition
-    diff_from_party_average: float
+    diff_from_party_average: float = 0
 
     @computed_field
     @property
@@ -292,7 +306,9 @@ class Vote(BaseModel):
                 return "Against motion (Teller)"
             case VotePosition.TELLAYE:
                 return "With motion (Teller)"
-            case _:  # type: ignore
+            case VotePosition.COLLECTIVE:
+                return "Collective"
+            case _:
                 raise ValueError(f"Invalid vote position {self.vote}")
 
     @computed_field
@@ -303,7 +319,11 @@ class Vote(BaseModel):
                 return 1
             case VotePosition.NO | VotePosition.TELLNO:
                 return -1
-            case VotePosition.ABSTENTION | VotePosition.ABSENT:
+            case (
+                VotePosition.ABSTENTION
+                | VotePosition.ABSENT
+                | VotePosition.COLLECTIVE
+            ):
                 return 0
             case _:  # type: ignore
                 raise ValueError(f"Invalid vote position {self.vote}")
@@ -329,15 +349,135 @@ class VoteWithDivisionID(Vote):
     division_id: int
 
 
+class VoteWithKey(Vote):
+    """
+    Small helper object when fetch votes
+    associated with multiple divisions
+    """
+
+    key: str
+
+
 class PartialAgreement(BaseModel):
     chamber_slug: AllowedChambers
     date: datetime.date = aliases("date", "division_date")
-    decision_ref: str  # Anticpated this will be the ref style used in TWFY to refer to the speech containing the agreement minus the date e.g. "a.974.1#g991.0"
+    decision_ref: str  # The bit after the date in the TWF ref
+    division_name: str = ""  # Here so this model can be used to load from YAML - not used to promote to AgreementInfo
 
     @computed_field
     @property
     def key(self) -> str:
         return f"{self.chamber_slug}-{self.date.isoformat()}-{self.decision_ref}"
+
+    @computed_field
+    @property
+    def source_gid(self) -> str:
+        # add the boiler plateos tuff here
+        debate_slug = Chamber(slug=self.chamber_slug).pw_alias()
+        return f"uk.org.publicwhip/{debate_slug}/{self.date.isoformat()}{self.decision_ref}"
+
+
+class AgreementInfo(BaseModel):
+    key: str = aliases("key", "agreement_key")
+    chamber: Chamber
+    date: datetime.date = aliases("date", "division_date")
+    decision_ref: str
+    division_name: str
+    vote_motion_analysis: VoteMotionAnalysis | None = None
+    motion: str = ""
+    voting_cluster: str = ""
+
+    @computed_field
+    @property
+    def source_gid(self) -> str:
+        return f"{self.date.isoformat()}{self.decision_ref}"
+
+    @computed_field
+    @property
+    def twfy_link(self) -> str:
+        return self.chamber.twfy_debate_link(self.source_gid)
+
+    def vote_type(self):
+        if self.vote_motion_analysis:
+            return VoteType(self.vote_motion_analysis.vote_type).display_name()
+        return "Unknown"
+
+    def url(self, request: Request):
+        return absolute_url_for(
+            request,
+            "agreement",
+            chamber_slug=self.chamber.slug,
+            date=self.date,
+            decision_ref=self.decision_ref,
+        )
+
+    def motion_uses_powers(self):
+        if self.vote_motion_analysis:
+            if self.vote_motion_analysis.motion_uses_powers():
+                return PowersAnalysis.USES_POWERS
+            else:
+                return PowersAnalysis.DOES_NOT_USE_POWERS
+        return PowersAnalysis.INSUFFICENT_INFO
+
+    @classmethod
+    async def upgrade_with_motions(
+        cls, items: list[AgreementInfo]
+    ) -> list[AgreementInfo]:
+        duck = await duck_core.child_query()
+        # at this point we only have special info for commons divisions
+        division_gids = [x.source_gid for x in items if x.chamber.slug == "commons"]
+        if len(division_gids) > 0:
+            # get the motion info
+            motions = await MotionQuery(gids=division_gids).to_model_list(
+                model=VoteMotionAnalysis, duck=duck, nan_to_none=True
+            )
+            # make lookup based on gid
+            motion_lookup = {x.gid: x for x in motions}
+        else:
+            motion_lookup = {}
+
+        # add the motion info to the division info
+        for item in items:
+            item.vote_motion_analysis = motion_lookup.get(
+                item.source_gid.split("/")[-1], None
+            )
+
+        return items
+
+    @classmethod
+    async def from_partials(
+        cls, partials: list[PartialAgreement]
+    ) -> list[AgreementInfo]:
+        duck = await duck_core.child_query()
+        if len(partials) == 0:
+            items = []
+        else:
+            items = await AgreementQueryKeys(
+                keys=[x.key for x in partials]
+            ).to_model_list(model=AgreementInfo, duck=duck)
+
+        items = await cls.upgrade_with_motions(items)
+
+        return items
+
+    @classmethod
+    async def from_partial(cls, partial: PartialAgreement) -> AgreementInfo:
+        """
+        Elevate to a agreement.
+        """
+        items = await cls.from_partials([partial])
+        if len(items) != 1:
+            raise ValueError("Expected one division to be returned")
+        return items[0]
+
+
+class PowersAnalysis(StrEnum):
+    USES_POWERS = "uses_powers"
+    DOES_NOT_USE_POWERS = "does_not_use_powers"
+    INSUFFICENT_INFO = "insufficent_info"
+
+    def display_name(self):
+        return self.value.replace("_", " ").title()
 
 
 class PartialDivision(BaseModel):
@@ -353,37 +493,6 @@ class PartialDivision(BaseModel):
     @property
     def key(self) -> str:
         return f"{self.chamber_slug}-{self.date.isoformat()}-{self.division_number}"
-
-
-class AgreementInfo(BaseModel):
-    key: str = aliases("key", "agreement_key")
-    house: Chamber
-    date: datetime.date = aliases("date", "division_date")
-    decision_ref: str
-    division_name: str
-    motion: str
-    voting_cluster: str = ""
-
-    def url(self, request: Request):
-        return ""
-
-    def motion_uses_powers(self):
-        return PowersAnalysis.INSUFFICENT_INFO
-
-    @classmethod
-    async def from_partials(
-        cls, partials: list[PartialAgreement]
-    ) -> list[AgreementInfo]:
-        return []
-
-
-class PowersAnalysis(StrEnum):
-    USES_POWERS = "uses_powers"
-    DOES_NOT_USE_POWERS = "does_not_use_powers"
-    INSUFFICENT_INFO = "insufficent_info"
-
-    def display_name(self):
-        return self.value.replace("_", " ").title()
 
 
 class DivisionInfo(BaseModel):
@@ -698,6 +807,74 @@ class PersonAndVotes(BaseModel):
             raise ValueError("Some votes have no division associated with them")
         df = pd.DataFrame(data=data)
         return style_df(df, percentage_columns=["Party alignment"])
+
+
+class AgreementAndVotes(BaseModel):
+    chamber: Chamber
+    date: datetime.date = aliases("date", "division_date")
+    division_ref: str
+    details: AgreementInfo
+    votes: list[Vote]
+
+    @classmethod
+    async def from_agreements(
+        cls, agreements: list[AgreementInfo]
+    ) -> list[AgreementAndVotes]:
+        """
+        Fetch multiple connected sets of divisions, votes, and breakdowns
+        """
+        duck = await duck_core.child_query()
+
+        # get the division_ids
+        keys = [d.key for d in agreements]
+
+        votes = await AgreementKeyVotesQuery(keys=keys).to_model_list(
+            model=VoteWithKey,
+            duck=duck,
+            validate=AgreementKeyVotesQuery.validate.NOT_ZERO,
+        )
+
+        items = []
+
+        for agreement in agreements:
+            agreement_votes = [v for v in votes if v.key == agreement.key]
+
+            items.append(
+                AgreementAndVotes(
+                    chamber=agreement.chamber,
+                    date=agreement.date,
+                    division_ref=agreement.decision_ref,
+                    details=agreement,
+                    votes=[
+                        Vote.model_validate(v.model_dump()) for v in agreement_votes
+                    ],
+                )
+            )
+
+        return items
+
+    @classmethod
+    async def from_agreement(cls, agreement: AgreementInfo) -> AgreementAndVotes:
+        agreements = await cls.from_agreements([agreement])
+        if len(agreements) != 1:
+            raise ValueError("Expected one agreement to be returned")
+
+        return agreements[0]
+
+    def votes_df(self, request: Request) -> str:
+        data = [
+            {
+                "Person": UrlColumn(
+                    url=v.person.votes_url(request), text=v.person.nice_name
+                ),
+                "Party": v.person.party,
+                "Vote": v.vote_desc,
+            }
+            for v in self.votes
+        ]
+
+        df = pd.DataFrame(data=data)
+        return style_df(df)
 
 
 class DivisionAndVotes(BaseModel):

--- a/src/twfy_votes/apps/decisions/queries.py
+++ b/src/twfy_votes/apps/decisions/queries.py
@@ -40,6 +40,19 @@ class MotionQuery(BaseQuery):
     gids: list[str]
 
 
+class AgreementQueryKeys(BaseQuery):
+    query_template = """
+    SELECT
+        * exclude (chamber_slug,),
+        chamber_slug as chamber__slug
+    FROM
+        pw_agreements
+    WHERE
+        key in {{ keys | inclause }}
+    """
+    keys: list[str]
+
+
 class DivisionQueryKeys(BaseQuery):
     query_template = """
         SELECT
@@ -76,6 +89,15 @@ class DivisionIDsQuery(BaseQuery):
             division_id in {{ division_ids | inclause }}
         """
     division_ids: list[int]
+
+
+class AgreementKeyVotesQuery(BaseQuery):
+    query_template = """
+    SELECT * from cm_agreement_present
+    WHERE
+        key in {{ keys | inclause }}
+    """
+    keys: list[str]
 
 
 class DivisionIdsVotesQuery(BaseQuery):

--- a/src/twfy_votes/apps/decisions/queries.py
+++ b/src/twfy_votes/apps/decisions/queries.py
@@ -191,6 +191,22 @@ class DivisionBreakDownQuery(BaseQuery):
     division_ids: list[int]
 
 
+class ChamberAgreementsQuery(BaseQuery):
+    query_template = """
+    SELECT
+        * exclude (chamber_slug,),
+        chamber_slug as chamber__slug
+    FROM
+        pw_agreements
+    WHERE
+        chamber_slug = {{ chamber_slug }} and
+        date between {{ start_date }} and {{ end_date }}
+    """
+    chamber_slug: str
+    start_date: datetime.date
+    end_date: datetime.date
+
+
 class ChamberDivisionsQuery(BaseQuery):
     query_template = """
     SELECT

--- a/src/twfy_votes/apps/decisions/router.py
+++ b/src/twfy_votes/apps/decisions/router.py
@@ -4,6 +4,7 @@ from ...helpers.static_fastapi.static import StaticAPIRouter
 from ...internal.settings import settings
 from ..core.dependencies import GetContext
 from .dependencies import (
+    GetAgreementAndVotes,
     GetChambersWithYearRange,
     GetDivisionAndVotes,
     GetDivisionListing,
@@ -70,6 +71,18 @@ async def api_division(division: GetDivisionAndVotes):
 @router.use_template("division.html")
 async def division(context: GetContext, division: GetDivisionAndVotes):
     context["item"] = division
+    return context
+
+
+@router.get("/decisions/agreement/{chamber_slug}/{date}/{decision_ref}.json")
+async def api_agreement(agreement: GetAgreementAndVotes):
+    return agreement
+
+
+@router.get_html("/decisions/agreement/{chamber_slug}/{date}/{decision_ref}")
+@router.use_template("agreement.html")
+async def agreement(context: GetContext, agreement: GetAgreementAndVotes):
+    context["item"] = agreement
     return context
 
 

--- a/src/twfy_votes/apps/decisions/router.py
+++ b/src/twfy_votes/apps/decisions/router.py
@@ -6,8 +6,8 @@ from ..core.dependencies import GetContext
 from .dependencies import (
     GetAgreementAndVotes,
     GetChambersWithYearRange,
+    GetDecisionListing,
     GetDivisionAndVotes,
-    GetDivisionListing,
     GetPeopleList,
     GetPersonAndRecords,
     GetPersonAndVotes,
@@ -86,22 +86,22 @@ async def agreement(context: GetContext, agreement: GetAgreementAndVotes):
     return context
 
 
-@router.get("/decisions/divisions/{chamber_slug}/{year}/{month}.json")
-@router.get("/decisions/divisions/{chamber_slug}/{year}.json")
-async def api_divisions_list(division_list: GetDivisionListing) -> GetDivisionListing:
+@router.get("/decisions/{chamber_slug}/{year}/{month}.json")
+@router.get("/decisions/{chamber_slug}/{year}.json")
+async def api_decisions_list(division_list: GetDecisionListing) -> GetDecisionListing:
     return division_list
 
 
-@router.get_html("/decisions/divisions/{chamber_slug}/{year}")
+@router.get_html("/decisions/{chamber_slug}/{year}")
 @router.use_template("division_list.html")
-async def divisions_list(context: GetContext, division_list: GetDivisionListing):
+async def decisions_list(context: GetContext, division_list: GetDecisionListing):
     context["search"] = division_list
     return context
 
 
-@router.get_html("/decisions/divisions/{chamber_slug}/{year}/{month}")
+@router.get_html("/decisions/{chamber_slug}/{year}/{month}")
 @router.use_template("division_list_month.html")
-async def divisions_list_month(context: GetContext, division_list: GetDivisionListing):
+async def decisions_list_month(context: GetContext, division_list: GetDecisionListing):
     context["search"] = division_list
     return context
 

--- a/src/twfy_votes/apps/policies/analysis.py
+++ b/src/twfy_votes/apps/policies/analysis.py
@@ -8,6 +8,10 @@ def public_whip_score_difference(
     num_strong_votes_absent: float,
     num_strong_votes_abstain: float,
     num_votes_abstain: float,
+    num_agreements_same: float,
+    num_strong_agreements_same: float,
+    num_agreements_different: float,
+    num_strong_agreements_different: float,
 ) -> float:
     """
     Calculate the classic Public Whip score for a difference between two MPs.
@@ -32,6 +36,8 @@ def public_whip_score_difference(
     But the second is that strong votes penalise absences more than normal votes.
 
     Strong votes were originally intended to reflect three line whips, but in practice have broadened out to mean 'more important'.
+
+    Do nothing with agreements for the moment.
 
     """
 
@@ -82,12 +88,18 @@ def simplified_score_difference(
     num_strong_votes_absent: float,
     num_strong_votes_abstain: float,
     num_votes_abstain: float,
+    num_agreements_same: float,
+    num_strong_agreements_same: float,
+    num_agreements_different: float,
+    num_strong_agreements_different: float,
 ) -> float:
     """
     This is a simplified version of the public whip scoring system.
     Normal weight votes are 'informative' only, and have no score.
     neither has an absence weight.
     Abstensions are recorded as present - but half the value of a normal vote.
+
+    Do nothing with agreements for the moment.
 
     """
 

--- a/src/twfy_votes/apps/policies/data_sources.py
+++ b/src/twfy_votes/apps/policies/data_sources.py
@@ -52,6 +52,41 @@ class policy_votes(YamlData[PartialPolicy]):
         return data
 
 
+@duck.as_python_source
+class policy_agreements(YamlData[PartialPolicy]):
+    """
+    Also add this as a seperate table to make query maths easier
+    """
+
+    yaml_source = Path("data", "policies", "*.yml")
+    validation_model = PartialPolicy
+
+    @classmethod
+    def post_validation(cls, models: list[PartialPolicy]) -> list[dict[str, Any]]:
+        data: list[dict[str, Any]] = []
+
+        for policy in models:
+            for decision in policy.agreement_links:
+                if decision.decision:
+                    data.append(
+                        {
+                            "policy_id": policy.id,
+                            "division_date": decision.decision.date,
+                            "chamber": decision.decision.chamber_slug,
+                            "decision_ref": decision.decision.decision_ref,
+                            "key": decision.decision.key,
+                            "strength": decision.strength,
+                            "strong_int": 1
+                            if decision.strength == PolicyStrength.STRONG
+                            else 0,
+                            "alignment": decision.alignment,
+                            "notes": decision.notes,
+                        }
+                    )
+
+        return data
+
+
 @duck.as_table
 class policy_votes_with_id:
     """

--- a/src/twfy_votes/apps/policies/models.py
+++ b/src/twfy_votes/apps/policies/models.py
@@ -149,7 +149,7 @@ class PartialPolicyDecisionLink(BaseModel, Generic[PartialDecisionType]):
                 return DecisionType.DIVISION
             case PartialAgreement():
                 return DecisionType.AGREEMENT
-            case _:  # type: ignore
+            case _:
                 raise ValueError("Must have agreement or division")
 
     @computed_field

--- a/src/twfy_votes/apps/policies/queries.py
+++ b/src/twfy_votes/apps/policies/queries.py
@@ -171,6 +171,22 @@ class PolicyDistributionQuery(BaseQuery):
     single_comparisons: bool = False
 
 
+class PolicyAgreementPersonQuery(BaseQuery):
+    query_template = """
+        select * from policy_agreement_count
+        where person_id = {{ person_id }}
+    """
+    person_id: int
+
+
+class PolicyAgreementPolicyQuery(BaseQuery):
+    query_template = """
+        select * from policy_agreement_count
+        where policy_id = {{ policy_id }}
+    """
+    policy_id: int
+
+
 class PolicyDistributionPersonQuery(BaseQuery):
     """
     Get the policy distribution calculation associated with a person.

--- a/src/twfy_votes/templates/agreement.html
+++ b/src/twfy_votes/templates/agreement.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+
+
+
+{% block content %}
+
+
+<h1>{{ item.details.chamber.name }} - {{ item.details.date }} - {{ item.details.decision_ref }}</h1>
+
+
+<h2>{{ item.details.division_name|safe }}</h2>
+
+<p><a href="{{ item.details.twfy_link }}">View agreement in TheyWorkForYou</a></p>
+
+<h2>Analysis</h2>
+
+
+{% if item.details.vote_motion_analysis %}
+
+<h3>Vote type</h3>
+
+<p>{{ item.details.vote_type() }}</p>
+
+<p>Motion detection isn't perfect: if the motion is amended prior to the vote, this may be an inaccurate summary.
+</p>
+
+{% endif %}
+
+
+<h3>Use of parliamentary powers</h3>
+
+{% with powers = item.details.motion_uses_powers() %}
+{% if powers == "uses_powers" %}
+<p>Yes. Automated analysis suggests this decision relates to Parliamentary powers.</p>
+{% elif powers == "does_not_use_powers" %}
+<p>No. Automated analysis suggests this decision does not relate to Parliamentary powers.</p>
+{% elif powers == "insufficent_info" %}
+<p>Insufficent information based on motion avaliable.</p>
+{% endif %}
+{% endwith %}
+
+
+{% if item.details.vote_motion_analysis %}
+
+<h2>Reduced Motion</h2>
+
+<p>{{ item.details.vote_motion_analysis.tidied_motion }}</p>
+
+{% with twfy_link = item.details.vote_motion_analysis.twfy_motion_url() %}
+{% if twfy_link %}
+<p><a href="{{ twfy_link }}">View motion in TheyWorkForYou</a></p>
+{% endif %}
+{% endwith %}
+
+<h2> More motion options </h2>
+<button data-bs-toggle="collapse" data-bs-target="#extracted-question">Extracted question</button>
+<div id="extracted-question" class="collapse ">
+    {{ item.details.vote_motion_analysis.question|safe }}
+</div>
+
+<button data-bs-toggle="collapse" data-bs-target="#full-motion">Full motion speech</button>
+<div id="full-motion" class="collapse ">
+    {{ item.details.vote_motion_analysis.full_motion_speech|safe }}
+
+</div>
+
+{% endif %}
+
+
+<h2>Voting list</h2>
+
+<p>Note: Agreements are not recorded against individuals. The following is a list of people who were {{
+    item.details.chamber.member_name }} at the time
+    this agreement was made.</p>
+
+
+{{ item.votes_df(request)|safe }}
+
+
+{% endblock content %}

--- a/src/twfy_votes/templates/agreement.html
+++ b/src/twfy_votes/templates/agreement.html
@@ -71,7 +71,7 @@
 
 <p>Note: Agreements are not recorded against individuals. The following is a list of people who were {{
     item.details.chamber.member_name }} at the time
-    this agreement was made.</p>
+    this decision was agreed.</p>
 
 
 {{ item.votes_df(request)|safe }}

--- a/src/twfy_votes/templates/decisions.html
+++ b/src/twfy_votes/templates/decisions.html
@@ -16,8 +16,7 @@
     <li>Agreements - when a decision is made without a vote being forced (and so there is no division list).</li>
 </ul>
 
-<p>Currently this page just covers divisions. Agreements may be included in policies at a future data as informative
-    information.</p>
+<p>Agreements are not systematically imported at this time - some have been added manually to support policies.</p>
 
 {% for c in chambers %}
 
@@ -25,7 +24,7 @@
 
 <ul>
     {% for year in c.year_range() %}
-    <li><a href="{{ url_for('divisions_list', chamber_slug=c.chamber.slug, year=year) }}">{{ year }}</a></li>
+    <li><a href="{{ url_for('decisions_list', chamber_slug=c.chamber.slug, year=year) }}">{{ year }}</a></li>
     {% endfor %}
 </ul>
 

--- a/src/twfy_votes/templates/division_list.html
+++ b/src/twfy_votes/templates/division_list.html
@@ -13,7 +13,7 @@
 <h2>{{ month }}</h2>
 
 <p><a
-        href="{{ url_for('divisions_list_month', chamber_slug=search.chamber.slug, year=divisions[0].date.year, month=divisions[0].date.month) }}">View
+        href="{{ url_for('decisions_list_month', chamber_slug=search.chamber.slug, year=divisions[0].date.year, month=divisions[0].date.month) }}">View
         as
         table</a></p>
 

--- a/src/twfy_votes/templates/policy.html
+++ b/src/twfy_votes/templates/policy.html
@@ -26,7 +26,6 @@
 <h2>Decisions</h2>
 
 <p>Decisions may be read as agreeing with the policy, or being against the policy.</p>
-<p>Votes may be neutral when relevant to a topic, but not clearly for or against.</p>
 
 <p>{{ decision_df|safe }}</p>
 

--- a/tests/test_twfy_votes.py
+++ b/tests/test_twfy_votes.py
@@ -81,12 +81,12 @@ class TestDivision(BaseTestResponse):
 
 
 class TestDivisionsYear(BaseTestResponse):
-    url = "/decisions/divisions/commons/2023"
+    url = "/decisions/commons/2023"
     has_json = True
 
 
 class TestDivisionsMonth(BaseTestResponse):
-    url = "/decisions/divisions/commons/2023/10"
+    url = "/decisions/commons/2023/10"
     has_json = True
 
 

--- a/tests/test_twfy_votes.py
+++ b/tests/test_twfy_votes.py
@@ -95,6 +95,11 @@ class TestPersonPolicy(BaseTestResponse):
     has_json = True
 
 
+class TestAgreementInfo(BaseTestResponse):
+    url = "/decisions/agreement/commons/2019-06-24/b.530.1"
+    has_json = True
+
+
 def test_valid_policy_xml(client: TestClient):
     response = client.get("/twfy-compatible/policies/6679.xml")
     assert response.status_code == 200


### PR DESCRIPTION
This completes the previously unfinished integration of the concept of agreements. 

Agreements are decisions taken without a vote. They are treated as similar to divisions for the purposes of automated motion analysis, but need different approaches for policy scoring.

As these are not tracked by Parliament as such - the twfy ref is used as the unique reference. This is the gid of the speech where the motion was agreed to (which might be hidden down the bottom of a normal speech). 

Currently, while the number of agreements that someone was a MP during the relevant time is counted for the purpose of policy calculations, nothing is actually done with this. The short term plan is that agreements should be 'weak' decision links only - for informative purposes.