### PR TITLE
Move people away from pw

### DIFF
--- a/databases/schema.yaml
+++ b/databases/schema.yaml
@@ -307,18 +307,15 @@ pw_manual_motions:
   manual_motion: VARCHAR
 pw_mp:
   mp_id: BIGINT
-  first_name: VARCHAR
-  last_name: VARCHAR
-  title: VARCHAR
   constituency: VARCHAR
+  person: BIGINT
   entered_house: VARCHAR
   left_house: VARCHAR
-  entered_reason: VARCHAR
-  left_reason: VARCHAR
-  person: BIGINT
   house: VARCHAR
-  gid: VARCHAR
   party: VARCHAR
+  first_name: VARCHAR
+  last_name: VARCHAR
+  nice_name: VARCHAR
 pw_vote:
   division_id: BIGINT
   mp_id: BIGINT
@@ -372,19 +369,17 @@ source_pw_division:
   house: VARCHAR
   clock_time: VARCHAR
 source_pw_mp:
-  mp_id: BIGINT
-  first_name: VARCHAR
-  last_name: VARCHAR
-  title: VARCHAR
+  membership_id: VARCHAR
+  person_id: VARCHAR
   constituency: VARCHAR
+  start_date: VARCHAR
+  end_date: VARCHAR
+  start_reason: VARCHAR
+  end_reason: VARCHAR
   party: VARCHAR
-  entered_house: VARCHAR
-  left_house: VARCHAR
-  entered_reason: VARCHAR
-  left_reason: VARCHAR
-  person: BIGINT
-  house: VARCHAR
-  gid: VARCHAR
+  chamber: VARCHAR
+  label: VARCHAR
+  role: VARCHAR
 source_pw_vote:
   division_id: BIGINT
   mp_id: BIGINT

--- a/src/twfy_votes/helpers/duck/types.py
+++ b/src/twfy_votes/helpers/duck/types.py
@@ -92,10 +92,7 @@ PythonDataSource = TypeVar(
 
 @runtime_checkable
 class DuckView(Protocol):
-    @property
-    @classmethod
-    def query(cls) -> str:
-        ...
+    query: str
 
 
 @runtime_checkable
@@ -125,10 +122,7 @@ BaseModelLikeType = TypeVar("BaseModelLikeType", bound=BaseModelLike)
 
 @runtime_checkable
 class SourceView(Protocol):
-    @classmethod
-    @property
-    def source(cls) -> FileSourceType:
-        ...
+    source: FileSourceType
 
 
 @runtime_checkable


### PR DESCRIPTION
Public whip currently contributes three tables:

 - membership
 - divisions
 - votes

This creates a new pw_mp table that imitates the pw version, but based on the parlparse/people.json.

