### PR TITLE
Add absence cap to scoring approach

### DIFF
--- a/src/twfy_votes/apps/policies/scoring.py
+++ b/src/twfy_votes/apps/policies/scoring.py
@@ -128,7 +128,9 @@ class SimplifiedScore(ScoringFuncProtocol):
         This is a simplified version of the public whip scoring system.
         Weak weight votes are 'informative' only, and have no score.
 
-        Absences do not move the needle.
+        Absences do not move the needle - but do impose a cap on the most extreme scores.
+        More than 1 strong absence prevents a score of 0.05 or 0.95 plus.
+        More than 1/3 strong absences prevents a score of 0.15 or 0.85 plus.
         Abstensions are recorded as present - but half the value of a weak vote.
 
         Strong agreements are counted the same as votes.
@@ -170,4 +172,32 @@ class SimplifiedScore(ScoringFuncProtocol):
         if avaliable_points == 0:
             return -1
 
-        return points / avaliable_points
+        score = points / avaliable_points
+
+        total = (
+            votes_same.strong
+            + votes_different.strong
+            + votes_absent.strong
+            + votes_abstain.strong
+        )
+
+        # here we are using the absences as a way of capping the descriptions avaliable
+        # we do this rather than give scores because we don't want more absences to drive to the middle of the roaedll
+        # but do want to avoid language that suggests a lack of absences in the underlying votes.
+        # the cap reflects where twfy switches its language.
+
+        # if more than one absent vote cap the score to prevent a 'consistently'
+        if votes_absent.strong > 1:
+            if score <= 0.05:
+                score = 0.06
+            elif score >= 0.95:
+                score = 0.94
+
+        # if more than one-third absent vote cap the score to prevent an 'almost always'
+        if votes_absent.strong >= total / 3:
+            if score <= 0.15:
+                score = 0.16
+            elif score >= 0.85:
+                score = 0.84
+
+        return score

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -182,7 +182,7 @@ def test_absences_no_effect():
     result_with_absences = SimplifiedScore.score(
         votes_same=ScoreFloatPair(weak=5.0, strong=5.0),
         votes_different=ScoreFloatPair(weak=0.0, strong=0.0),
-        votes_absent=ScoreFloatPair(weak=5.0, strong=0.0),
+        votes_absent=ScoreFloatPair(weak=5.0, strong=1.0),
         votes_abstain=ScoreFloatPair(weak=0.0, strong=0.0),
         agreements_same=ScoreFloatPair(weak=5.0, strong=5.0),
         agreements_different=ScoreFloatPair(weak=0.0, strong=0.0),
@@ -191,6 +191,66 @@ def test_absences_no_effect():
     assert (
         result == result_with_absences
     ), "Expected score to be the same with or without absences"
+
+
+def test_absence_cap_strong():
+    result_with_absences = SimplifiedScore.score(
+        votes_same=ScoreFloatPair(weak=5.0, strong=10.0),
+        votes_different=ScoreFloatPair(weak=0.0, strong=0.0),
+        votes_absent=ScoreFloatPair(weak=0.0, strong=2.0),
+        votes_abstain=ScoreFloatPair(weak=0.0, strong=0.0),
+        agreements_same=ScoreFloatPair(weak=0.0, strong=0.0),
+        agreements_different=ScoreFloatPair(weak=0.0, strong=0.0),
+    )
+
+    assert (
+        result_with_absences == 0.06
+    ), f"Expected score to be the cap - instead was {result_with_absences}"
+
+
+def test_absence_cap_strong_against():
+    result_with_absences = SimplifiedScore.score(
+        votes_same=ScoreFloatPair(weak=0.0, strong=0.0),
+        votes_different=ScoreFloatPair(weak=5.0, strong=10.0),
+        votes_absent=ScoreFloatPair(weak=0.0, strong=2.0),
+        votes_abstain=ScoreFloatPair(weak=0.0, strong=0.0),
+        agreements_same=ScoreFloatPair(weak=0.0, strong=0.0),
+        agreements_different=ScoreFloatPair(weak=0.0, strong=0.0),
+    )
+
+    assert (
+        result_with_absences == 0.94
+    ), f"Expected score to be the cap - instead was {result_with_absences}"
+
+
+def test_absence_cap_one_third():
+    result_with_absences = SimplifiedScore.score(
+        votes_same=ScoreFloatPair(weak=5.0, strong=10.0),
+        votes_different=ScoreFloatPair(weak=0.0, strong=0.0),
+        votes_absent=ScoreFloatPair(weak=0.0, strong=5.0),
+        votes_abstain=ScoreFloatPair(weak=0.0, strong=0.0),
+        agreements_same=ScoreFloatPair(weak=0.0, strong=0.0),
+        agreements_different=ScoreFloatPair(weak=0.0, strong=0.0),
+    )
+
+    assert (
+        result_with_absences == 0.16
+    ), f"Expected score to be the cap - instead was {result_with_absences}"
+
+
+def test_absence_cap_one_third_against():
+    result_with_absences = SimplifiedScore.score(
+        votes_same=ScoreFloatPair(weak=0.0, strong=0.0),
+        votes_different=ScoreFloatPair(weak=5.0, strong=10.0),
+        votes_absent=ScoreFloatPair(weak=0.0, strong=5.0),
+        votes_abstain=ScoreFloatPair(weak=0.0, strong=0.0),
+        agreements_same=ScoreFloatPair(weak=0.0, strong=0.0),
+        agreements_different=ScoreFloatPair(weak=0.0, strong=0.0),
+    )
+
+    assert (
+        result_with_absences == 0.84
+    ), f"Expected score to be the cap - instead was {result_with_absences}"
 
 
 def test_weak_agreements_change_nothing():


### PR DESCRIPTION
Add absence cap to prevent more extreme values when there are notable numbers of absences (without forcing it towards the middle of the range). 