### PR TITLE
Switch to TWFY source files

### DIFF
--- a/src/twfy_votes/apps/decisions/models.py
+++ b/src/twfy_votes/apps/decisions/models.py
@@ -73,7 +73,7 @@ class AllowedChambers(StrEnum):
     COMMONS = "commons"
     LORDS = "lords"
     SCOTLAND = "scotland"
-    WALES = "wales"
+    SENEDD = "senedd"
     NI = "ni"
 
 
@@ -184,7 +184,7 @@ class Chamber(BaseModel):
                 return "Lords"
             case "scotland":
                 return "MSPs"
-            case "wales":
+            case "senedd":
                 return "MSs"
             case "ni":
                 return "AMs"
@@ -201,7 +201,7 @@ class Chamber(BaseModel):
                 return "House of Lords"
             case "scotland":
                 return "Scottish Parliament"
-            case "wales":
+            case "senedd":
                 return "Senedd"
             case "ni":
                 return "Northern Ireland Assembly"
@@ -225,7 +225,7 @@ class Chamber(BaseModel):
                 return "lords"
             case "scotland":
                 return "sp"
-            case "wales":
+            case "senedd":
                 return "senedd"
             case "ni":
                 return "ni"
@@ -376,7 +376,7 @@ class VoteWithDivisionID(Vote):
     associated with multiple divisions
     """
 
-    division_id: int
+    division_id: str
 
 
 class VoteWithKey(Vote):
@@ -529,13 +529,13 @@ class DivisionInfo(BaseModel):
     key: str = aliases("key", "division_key")
     chamber: Chamber
     date: datetime.date = aliases("date", "division_date")
-    division_id: int
+    division_id: str
     division_number: int
-    division_name: str
-    source_url: str
-    motion: str
+    division_name: str = aliases("division_name", "division_title")
+    source_url: str | None = None
+    motion: str = ""
     manual_motion: str
-    debate_url: str
+    debate_url: str | None = None
     source_gid: str
     debate_gid: str
     clock_time: str | None = None
@@ -805,7 +805,7 @@ class DecisionListing(BaseModel):
 
 
 class DivisionBreakdown(BaseModel):
-    division_id: int
+    division_id: str
     grouping: str | None = None
     vote_participant_count: int
     for_motion: int

--- a/src/twfy_votes/apps/decisions/queries.py
+++ b/src/twfy_votes/apps/decisions/queries.py
@@ -113,7 +113,7 @@ class DivisionIdsVotesQuery(BaseQuery):
         nice_name as person__nice_name,
         party_name as person__party,
         person_id as person__person_id,
-        pw_votes_with_party_difference.* exclude (division_id, __index_level_0__, given_name, last_name, nice_name, party)
+        pw_votes_with_party_difference.* exclude (division_id, given_name, last_name, nice_name, party)
     FROM
         pw_votes_with_party_difference
     WHERE
@@ -131,7 +131,7 @@ class DivisionVotesQuery(BaseQuery):
         nice_name as person__nice_name,
         party as person__party,
         person_id as person__person_id,
-        pw_votes_with_party_difference.* exclude (division_id, __index_level_0__)
+        pw_votes_with_party_difference.* exclude (division_id)
     FROM
         pw_division
     JOIN pw_votes_with_party_difference using (division_id)
@@ -153,7 +153,7 @@ class PersonVotesQuery(BaseQuery):
         nice_name as person__nice_name,
         party as person__party,
         person_id as person__person_id,
-        pw_votes_with_party_difference.* exclude (division_id, __index_level_0__),
+        pw_votes_with_party_difference.* exclude (division_id),
         division_key as division__division_key,
         chamber as division__chamber__slug,
         division_id as division__division_id,

--- a/src/twfy_votes/apps/policies/tools.py
+++ b/src/twfy_votes/apps/policies/tools.py
@@ -38,7 +38,7 @@ def create_new_policy(
     starting_value = {
         AllowedChambers.COMMONS: 20001,
         AllowedChambers.LORDS: 30001,
-        AllowedChambers.WALES: 40001,
+        AllowedChambers.SENEDD: 40001,
         AllowedChambers.SCOTLAND: 50001,
         AllowedChambers.NI: 60001,
     }


### PR DESCRIPTION
Proof of concept of switching the source from public whip to theyworkforyou parquet exports. 

Basics works fine - but not ready yet and moving on for moment. 

Issues:


- [ ]  Don't have equivlant of debate_gid in division table
- [ ]  Vote table uses person_id, not membership_id - currently recreated in query here, but could be done in the initial export
- [ ]  Flag language in division export
- [ ]  Adding more votes pushes some queries into needing more memory. Need some restructure (these are cached anyway) to be slower but less memory intensive. 
- [ ]  People listing for non-commons doesn't work - I think a few different reasons.
- [ ]  missing source_url in divisions table - what are we actually using that for and is it needed. 
- [ ]  Do we need that motion field in divisions table? Or it this taken care of with the join with manual motions
- [ ]  Rather than directly querying twfy, want a data site intermediary for ease of API access. 