### PR TITLE
Fix asyncio.Cancelled error

### DIFF
--- a/src/twfy_votes/apps/core/db.py
+++ b/src/twfy_votes/apps/core/db.py
@@ -1,7 +1,7 @@
 # This notebook imports legacy publicwhip policy information into yaml files that power new database
 
 from ...helpers.duck.core import AsyncDuckDBManager
-from ...internal.db import duck_core, get_db_lifespan
+from ...internal.db import LifeSpanManager, duck_core
 from ..decisions.data_sources import duck as decisions_duck
 from ..policies.data_sources import duck as policies_duck
 
@@ -49,4 +49,4 @@ async def reload_database():
 
 load_common_core = CommonCore().load_common_core
 
-db_lifespan = get_db_lifespan(data_sources)
+db_lifespan = LifeSpanManager(data_sources)

--- a/src/twfy_votes/internal/db.py
+++ b/src/twfy_votes/internal/db.py
@@ -1,4 +1,6 @@
-from contextlib import asynccontextmanager
+import asyncio
+from types import TracebackType
+from typing import Type
 
 from fastapi import FastAPI
 
@@ -21,13 +23,33 @@ def get_core():
 duck_core = get_core()
 
 
-def get_db_lifespan(queries: list[DuckQuery]):
-    @asynccontextmanager
-    async def lifespan(app: FastAPI | None = None):
-        # Load the ML model
-        await duck_core.get_loaded_core(queries)
-        yield
+class LifeSpanManager:
+    def __init__(self, queries: list[DuckQuery]):
+        self.queries = queries
+        self.tasks = []
+
+    def __call__(self, app: FastAPI | None = None):
+        """
+        We don't actualy need the app, but fastapi will pass it in.
+        """
+        self.app = app
+        return self
+
+    async def __aenter__(self):
+        db_task = asyncio.create_task(duck_core.get_loaded_core(self.queries))
+        self.tasks.append(db_task)
+        await db_task
+
+    async def __aexit__(
+        self, exc_t: Type[BaseException], exc_v: BaseException, exc_tb: TracebackType
+    ) -> None:
+        for task in self.tasks:
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass  # Handle the cancellation appropriately
+        self.tasks = []
         duck_core.delete_database()
         await duck_core.close()
-
-    return lifespan


### PR DESCRIPTION
Use more complicated LifeSpanManager to handle debug server resetting while loading.

This is mostly a dev enviroment issue - but is annoying.

Alternative approach is to *not* reset the database in these cases. 