### PR TITLE
Update ENV assignments in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-bullseye
 
 ARG TWFY_API_KEY=""
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 COPY pyproject.toml poetry.loc[k] /
 RUN curl -sSL https://install.python-poetry.org | python - && \
     echo 'export PATH="/root/.local/bin:$PATH"' > ~/.bashrc && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM python:3.10-bullseye
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 COPY pyproject.toml poetry.loc[k] /
 RUN curl -sSL https://install.python-poetry.org | python - && \
     echo 'export PATH="/root/.local/bin:$PATH"' > ~/.bashrc && \


### PR DESCRIPTION
This will avoid legacy format warnings when building as the space separated format is deprecated.

See: https://docs.docker.com/reference/build-checks/legacy-key-value-format/

Fixes #53